### PR TITLE
Scene challenges + progress track changes

### DIFF
--- a/TheOracle2/Clock/CampaignClock.cs
+++ b/TheOracle2/Clock/CampaignClock.cs
@@ -2,18 +2,18 @@ namespace TheOracle2.GameObjects;
 public class CampaignClock : Clock
 {
   public CampaignClock(Embed embed) : base(embed) { }
-  public CampaignClock(EmbedField embedField) : base(embedField) { }
-  public CampaignClock(ClockSize segments, int filledSegments, string text) : base(segments, filledSegments, text) { }
+
+  public CampaignClock(ClockSize segments, int filledSegments, string title, string description = "") : base(segments, filledSegments, title, description) { }
   public override string EmbedCategory => "Campaign Clock";
   public override string FillMessage => "The event is triggered or the project is complete. Envision the outcome and the impact on your setting.";
 
-  private static SelectMenuOptionBuilder AdvanceSelectMenuOption(int odds, string label, IEmote emoji)
+  private static SelectMenuOptionBuilder AdvanceAskOption(int odds, string label, IEmote emoji)
   {
     return new SelectMenuOptionBuilder()
     .WithEmote(emoji)
     .WithLabel(label)
     .WithDescription(odds == 100 ? "Advance the clock without rolling Ask the Oracle." : $"{odds}% chance for the clock to advance.")
-    .WithValue(odds == 100 ? "advance" : $"advance-{odds}")
+    .WithValue(odds == 100 ? "clock-advance" : $"clock-advance-{odds}")
     .WithDefault(false)
     ;
   }
@@ -23,21 +23,15 @@ public class CampaignClock : Clock
     ;
     if (!IsFull)
     {
-      selectMenu = selectMenu.AddOption(AdvanceSelectMenuOption(100, IClock.AdvanceLabel, IClock.OddsEmoji[100]));
+      selectMenu = selectMenu.AddOption(AdvanceAskOption(100, IClock.AdvanceLabel, IClock.OddsEmoji[100]));
       foreach (AskOption odds in Enum.GetValues(typeof(AskOption)))
       {
         string label = $"{IClock.AdvanceLabel} ({OracleAnswer.OddsString[(int)odds]})";
-        SelectMenuOptionBuilder menuOption = AdvanceSelectMenuOption((int)odds, label, IClock.OddsEmoji[(int)odds]);
+        SelectMenuOptionBuilder menuOption = AdvanceAskOption((int)odds, label, IClock.OddsEmoji[(int)odds]);
         selectMenu = selectMenu.AddOption(menuOption);
       }
     }
-    return selectMenu.AddOption(
-      new SelectMenuOptionBuilder()
-      .WithLabel("Reset clock")
-      .WithValue("reset")
-      .WithEmote(IClock.UxEmoji["reset"])
-      .WithDefault(false)
-      )
+    return selectMenu.AddOption(AdvanceOption())
     .WithPlaceholder("Advance clock...")
     .WithCustomId("clock-menu")
     .WithMinValues(0)

--- a/TheOracle2/Clock/CampaignClock.cs
+++ b/TheOracle2/Clock/CampaignClock.cs
@@ -4,7 +4,7 @@ public class CampaignClock : Clock
   public CampaignClock(Embed embed) : base(embed) { }
   public CampaignClock(EmbedField embedField) : base(embedField) { }
   public CampaignClock(ClockSize segments, int filledSegments, string text) : base(segments, filledSegments, text) { }
-  public override string ClockType => "Campaign Clock";
+  public override string EmbedCategory => "Campaign Clock";
   public override string FillMessage => "The event is triggered or the project is complete. Envision the outcome and the impact on your setting.";
 
   private static SelectMenuOptionBuilder AdvanceSelectMenuOption(int odds, string label, IEmote emoji)

--- a/TheOracle2/Clock/Clock.cs
+++ b/TheOracle2/Clock/Clock.cs
@@ -4,33 +4,33 @@ public abstract class Clock : IClock
 {
   protected Clock(Embed embed)
   {
-    Text = embed.Title;
+    Title = embed.Title;
     string[] clockString = embed.Description.Split("/");
     Filled = int.Parse(clockString[0]);
     Segments = int.Parse(clockString[1]);
   }
   protected Clock(EmbedField embedField)
   {
-    Text = embedField.Name.Replace(ClockType + ": ", "");
+    // Title = embedField.Name.Replace(EmbedCategory + ": ", "");
     string[] clockString = embedField.Value.Split("/");
     Filled = int.Parse(clockString[0]);
     Segments = int.Parse(clockString[1]);
   }
-  protected Clock(ClockSize segments = (ClockSize)6, int filledSegments = 0, string text = "")
+  protected Clock(ClockSize segments = (ClockSize)6, int filledSegments = 0, string title = "")
   {
     if (filledSegments < 0 || filledSegments > ((int)segments))
     {
       throw new ArgumentOutOfRangeException(nameof(filledSegments), "filledSegments can't exceed segments");
     }
-    Text = text;
+    Title = title;
     Segments = (int)segments;
     Filled = filledSegments;
   }
-
   public int Segments { get; }
   public int Filled { get; set; }
-  public string Text { get; set; }
-  public abstract string ClockType { get; }
+  public string Title { get; set; }
+  public string Description { get; set; }
+  public abstract string EmbedCategory { get; }
   public bool IsFull => Filled >= Segments;
   public override string ToString()
   {
@@ -39,8 +39,8 @@ public abstract class Clock : IClock
   public virtual EmbedBuilder ToEmbed()
   {
     return new EmbedBuilder()
-      .WithAuthor(ClockType)
-      .WithTitle(Text)
+      .WithAuthor(EmbedCategory)
+      .WithTitle(Title)
       .WithDescription(ToString())
       .WithThumbnailUrl(
         IClock.Images[Segments][Filled])
@@ -51,7 +51,8 @@ public abstract class Clock : IClock
   public virtual EmbedFieldBuilder ToEmbedField()
   {
     return new EmbedFieldBuilder()
-    .WithName($"{ClockType}: {Text}")
+    // .WithName($"{EmbedCategory}: {Title}")
+    .WithName("Clock")
     .WithValue(ToString());
   }
   public EmbedBuilder AlertEmbed()
@@ -59,7 +60,7 @@ public abstract class Clock : IClock
     EmbedBuilder embed = new EmbedBuilder().WithThumbnailUrl(
       IClock.Images[Segments][Filled])
     .WithColor(IClock.ColorRamp[Segments][Filled])
-    .WithAuthor($"{ClockType}: {Text}")
+    .WithAuthor($"{EmbedCategory}: {Title}")
     .WithTitle(IsFull ? "The clock fills!" : $"The clock advances to {ToString()}");
     if (IsFull)
     {
@@ -67,7 +68,6 @@ public abstract class Clock : IClock
     }
     return embed;
   }
-
   public virtual string FillMessage { get; set; }
   public ButtonBuilder AdvanceButton(string customId = "clock-advance")
   {

--- a/TheOracle2/Clock/IClock.cs
+++ b/TheOracle2/Clock/IClock.cs
@@ -9,8 +9,9 @@ public interface IClock
   public string FillMessage { get; set; }
   public int Segments { get; }
   public int Filled { get; set; }
-  public string Text { get; set; }
-  public string ClockType { get; }
+  public string Title { get; set; }
+  public string Description { get; set; }
+  public string EmbedCategory { get; }
   public bool IsFull => Filled >= Segments;
   public static string AdvanceLabel => "Advance Clock";
   public ComponentBuilder MakeComponents();

--- a/TheOracle2/Clock/IClock.cs
+++ b/TheOracle2/Clock/IClock.cs
@@ -15,6 +15,23 @@ public interface IClock
   public bool IsFull => Filled >= Segments;
   public static string AdvanceLabel => "Advance Clock";
   public ComponentBuilder MakeComponents();
+  public static EmbedBuilder ToEmbedStub(string embedCategory, string title, int segments, int filled)
+  {
+    return new EmbedBuilder()
+    .WithAuthor(embedCategory)
+    .WithTitle(title)
+    .WithThumbnailUrl(
+      IClock.Images[segments][filled])
+    .WithColor(
+      IClock.ColorRamp[segments][filled]);
+  }
+  public static Tuple<int, int> Parseclock(Embed embed)
+  {
+    EmbedField clockField = embed.Fields.FirstOrDefault(field => field.Name == "Clock");
+    string[] valueStrings = clockField.Value.Split("/");
+    int[] values = valueStrings.Select(value => int.Parse(value)).ToArray();
+    return new Tuple<int, int>(values[0], values[1]);
+  }
   public static readonly Dictionary<string, Emoji> UxEmoji = new()
   {
     { "reset", new Emoji("↩️") }
@@ -109,6 +126,7 @@ public interface IClock
     {
       "Campaign Clock" => new CampaignClock(embed),
       "Tension Clock" => new TensionClock(embed),
+      "Scene Challenge" => new SceneChallenge(embed),
       _ => throw new ArgumentOutOfRangeException(nameof(embed), "Embed must be a 'Campaign Clock', 'Tension Clock', or 'Scene Challenge'"),
     };
   }

--- a/TheOracle2/Clock/SceneChallenge.cs
+++ b/TheOracle2/Clock/SceneChallenge.cs
@@ -1,0 +1,68 @@
+namespace TheOracle2.GameObjects;
+public class SceneChallenge : Clock, IProgressTrack
+{
+  public SceneChallenge(Embed embed) : base(embedField: embed.Fields.FirstOrDefault(field => field.Name == "Clock"))
+  {
+    Title = embed.Title;
+    EmbedField progressField = embed.Fields.FirstOrDefault(field => field.Name.StartsWith("Progress [", StringComparison.InvariantCulture));
+    Ticks = IProgressTrack.EmojiToTicks(progressField.Value);
+  }
+  public SceneChallenge(ClockSize segments = (ClockSize)6, int filledSegments = 0, int ticks = 0, string title = "") : base(segments, filledSegments, title)
+  {
+    Ticks = ticks;
+  }
+  public ChallengeRank Rank { get; set; } = ChallengeRank.Formidable;
+
+  public RankData RankInfo { get => IProgressTrack.RankInfo[Rank]; }
+
+  public int Ticks { get; set; }
+  public int Score => (int)(Ticks / 4);
+  public override string EmbedCategory { get; } = "Scene Challenge";
+  public string ProgressScoreString { get => $"{Score}/10"; }
+  public override EmbedBuilder ToEmbed()
+  {
+    return base.ToEmbed()
+    .AddField(IProgressTrack.ToEmbedField(ProgressScoreString, Ticks))
+    .AddField(ToEmbedField())
+    .WithDescription("")
+    ;
+  }
+  public virtual ButtonBuilder ClearButton()
+  {
+    return IProgressTrack
+      .ClearButton(RankInfo.MarkTrack)
+        .WithDisabled(Ticks == 0);
+  }
+  public ButtonBuilder ResolveButton()
+  {
+    return IProgressTrack
+      .ResolveButton(Score)
+      .WithLabel("Resolve challenge")
+    ;
+  }
+  public ButtonBuilder MarkButton()
+  {
+    return IProgressTrack
+      .MarkButton(RankInfo.MarkTrack)
+      .WithDisabled(Score >= 10 || IsFull)
+    ;
+  }
+
+  public override ComponentBuilder MakeComponents()
+  {
+    ComponentBuilder components = new ComponentBuilder()
+      .WithButton(ClearButton())
+      .WithButton(MarkButton())
+      .WithButton(ResolveButton())
+      ;
+    foreach (ActionRowBuilder row in
+        base.MakeComponents().ActionRows)
+    {
+      foreach (ButtonBuilder button in row.Components)
+      {
+        components = components.WithButton(button);
+      }
+    }
+    return components;
+  }
+}

--- a/TheOracle2/Clock/TensionClock.cs
+++ b/TheOracle2/Clock/TensionClock.cs
@@ -3,8 +3,7 @@ namespace TheOracle2.GameObjects;
 public class TensionClock : Clock
 {
   public TensionClock(Embed embed) : base(embed) { }
-  public TensionClock(EmbedField embedField) : base(embedField) { }
-  public TensionClock(ClockSize segments, int filledSegments, string text) : base(segments, filledSegments, text) { }
+  public TensionClock(ClockSize segments, int filledSegments, string title, string description = "") : base(segments, filledSegments, title, description) { }
   public override string EmbedCategory => "Tension Clock";
   public override string FillMessage => "The threat or deadline triggers. This should result in harrowing problems for your character. It may even force you to abandon an expedition, fight, vow, or other challenge.";
 }

--- a/TheOracle2/Clock/TensionClock.cs
+++ b/TheOracle2/Clock/TensionClock.cs
@@ -5,6 +5,6 @@ public class TensionClock : Clock
   public TensionClock(Embed embed) : base(embed) { }
   public TensionClock(EmbedField embedField) : base(embedField) { }
   public TensionClock(ClockSize segments, int filledSegments, string text) : base(segments, filledSegments, text) { }
-  public override string ClockType => "Tension Clock";
+  public override string EmbedCategory => "Tension Clock";
   public override string FillMessage => "The threat or deadline triggers. This should result in harrowing problems for your character. It may even force you to abandon an expedition, fight, vow, or other challenge.";
 }

--- a/TheOracle2/Commands/ClockCommand.cs
+++ b/TheOracle2/Commands/ClockCommand.cs
@@ -97,7 +97,7 @@ public class ClockComponents : InteractionModuleBase<SocketInteractionContext<So
     string optionValue = values.FirstOrDefault();
     if (int.TryParse(optionValue.Replace("advance-", ""), out int odds))
     {
-      OracleAnswer answer = new(random, odds, $"Does the clock *{clock.Text}* advance?");
+      OracleAnswer answer = new(random, odds, $"Does the clock *{clock.Title}* advance?");
       EmbedBuilder answerEmbed = answer.ToEmbed();
       if (answer.IsYes)
       {

--- a/TheOracle2/Commands/ClockCommand.cs
+++ b/TheOracle2/Commands/ClockCommand.cs
@@ -15,10 +15,12 @@ public class ClockCommand : InteractionModuleBase
     Choice("6 segments", 6),
     Choice("8 segments", 8),
     Choice("10 segments", 10)]
-    int segments
+    int segments,
+    [Summary(description: "An optional description.")]
+    string description=""
   )
   {
-    CampaignClock campaignClock = new((ClockSize)segments, 0, title);
+    CampaignClock campaignClock = new((ClockSize)segments, 0, title, description);
     await RespondAsync(
       embed: campaignClock.ToEmbed().Build(),
       components: campaignClock.MakeComponents().Build()
@@ -34,117 +36,36 @@ public class ClockCommand : InteractionModuleBase
     Choice("6 segments", 6),
     Choice("8 segments", 8),
     Choice("10 segments", 10)]
-    int segments
+    int segments,
+    [Summary(description: "An optional description.")]
+    string description=""
   )
   {
-    TensionClock tensionClock = new((ClockSize)segments, 0, title);
+    TensionClock tensionClock = new((ClockSize)segments, 0, title, description);
     await RespondAsync(
       embed: tensionClock.ToEmbed().Build(),
       components: tensionClock.MakeComponents().Build());
   }
 
-  // [SlashCommand("scene-challenge", "Set a clock for a scene challenge")]
-  // public async Task BuildSceneChallenge(
-  //   [Summary(description: "The scene challenge's objective.")]
-  //   string title,
-  //   [Summary(description: "The number of clock segments. Default = 6, severe disadvantage = 4, strong advantage = 8.")]
-  //   [Choice("4 segments", 4),
-  //   Choice("6 segments", 6),
-  //   Choice("8 segments", 8)]
-  //   int segments=6)
-  // {
-  //   await RespondAsync("NYI");
-  // }
-}
+  [SlashCommand("scene-challenge", "Create a scene challenge for extended non-combat scenes against threats or other characters (p. 235)")]
+  public async Task BuildSceneChallenge(
+    [Summary(description: "The scene challenge's objective.")]
+    string title,
+    [Summary(description: "The number of clock segments. Default = 6, severe disadvantage = 4, strong advantage = 8.")]
+    [Choice("4 segments", 4),
+    Choice("6 segments", 6),
+    Choice("8 segments", 8)]
+    int segments=6,
+    [Summary(description: "An optional description.")]
+    string description = "")
+  {
+    SceneChallenge sceneChallenge = new((ClockSize)segments, 0, 0, title, description);
+    EmbedBuilder embed = sceneChallenge.ToEmbed();
+    ComponentBuilder components = sceneChallenge.MakeComponents();
 
-public class ClockComponents : InteractionModuleBase<SocketInteractionContext<SocketMessageComponent>>
-{
-  private readonly Random random;
-  public ClockComponents(Random random)
-  {
-    this.random = random;
-  }
-  [ComponentInteraction("clock-reset")]
-  public async Task ResetClock()
-  {
-    var interaction = Context.Interaction as SocketMessageComponent;
-    var clock = IClock.FromEmbed(interaction.Message.Embeds.FirstOrDefault());
-    await interaction.UpdateAsync(msg =>
-  {
-    clock.Filled = 0;
-    msg.Components = clock.MakeComponents().Build();
-    msg.Embed = clock.ToEmbed().Build();
-  });
-  }
-  [ComponentInteraction("clock-advance")]
-  public async Task AdvanceClock()
-  {
-    var interaction = Context.Interaction as SocketMessageComponent;
-    var clock = IClock.FromEmbed(interaction.Message.Embeds.FirstOrDefault());
-    await interaction.UpdateAsync(msg =>
-    {
-      clock.Filled++;
-      msg.Components = clock.MakeComponents().Build();
-      msg.Embed = clock.ToEmbed().Build();
-    });
-    await interaction.FollowupAsync(embed: clock.AlertEmbed().Build());
-  }
-  [ComponentInteraction("clock-menu")]
-  public async Task AdvanceClockMenu(string[] values)
-  {
-    var interaction = Context.Interaction as SocketMessageComponent;
-    var clock = IClock.FromEmbed(interaction.Message.Embeds.FirstOrDefault());
-    string optionValue = values.FirstOrDefault();
-    if (int.TryParse(optionValue.Replace("advance-", ""), out int odds))
-    {
-      OracleAnswer answer = new(random, odds, $"Does the clock *{clock.Title}* advance?");
-      EmbedBuilder answerEmbed = answer.ToEmbed();
-      if (answer.IsYes)
-      {
-        clock.Filled += answer.IsMatch ? 2 : 1;
-        if (answer.IsMatch)
-        {
-          answerEmbed.WithFooter("You rolled a match! Envision how this situation or project gains dramatic support or inertia.");
-        }
-        string append = answer.IsMatch ? $"The clock advances **twice** to {clock.ToString()}." : $"The clock advances to {clock.ToString()}.";
-        answerEmbed.Description += "\n" + append;
-        answerEmbed = answerEmbed.WithThumbnailUrl(IClock.Images[clock.Segments].ElementAt(clock.Filled));
-      }
-      if (!answer.IsYes)
-      {
-        if (answer.IsMatch)
-        {
-          answerEmbed = answerEmbed.WithFooter("You rolled a match! Envision a surprising turn of events which pits new factors or forces against the clock.");
-        }
-        answerEmbed.Description += "\n" + $"The clock remains at {clock.ToString()}";
-      }
-      answerEmbed = answerEmbed
-        .WithThumbnailUrl(IClock.Images[clock.Segments][clock.Filled])
-        .WithColor(IClock.ColorRamp[clock.Segments][clock.Filled]);
-      await interaction.UpdateAsync(msg =>
-      {
-        msg.Components = clock.MakeComponents().Build();
-        msg.Embed = clock.ToEmbed().Build();
-      });
-      await interaction.FollowupAsync(embed: answerEmbed.Build());
-      return;
-    }
-    switch (optionValue)
-    {
-      case "reset":
-        clock.Filled = 0;
-        break;
-      case "advance":
-        clock.Filled++;
-        break;
-      default:
-        throw new ArgumentOutOfRangeException(nameof(optionValue), "Could not parse integer or valid string from select menu option value.");
-    }
-    await interaction.UpdateAsync(msg =>
-    {
-      msg.Components = clock.MakeComponents().Build();
-      msg.Embed = clock.ToEmbed().Build();
-    });
-    await interaction.FollowupAsync(embed: clock.AlertEmbed().Build());
+    await RespondAsync(
+      embed: embed.Build(),
+      components: components.Build()
+      );
   }
 }

--- a/TheOracle2/Commands/CommonComponents.cs
+++ b/TheOracle2/Commands/CommonComponents.cs
@@ -1,0 +1,181 @@
+using Discord.Interactions;
+using Discord.WebSocket;
+using TheOracle2.GameObjects;
+namespace TheOracle2;
+
+public class CommonComponents : InteractionModuleBase<SocketInteractionContext<SocketMessageComponent>>
+{
+  private readonly Random Random;
+  public CommonComponents(Random random)
+  {
+    Random = random;
+  }
+  [ComponentInteraction("progress-mark:*")]
+  public async Task MarkProgress(string tickString)
+  {
+    var interaction = Context.Interaction as SocketMessageComponent;
+    int ticksToAdd = int.Parse(tickString);
+    var progressTrack = IProgressTrack.FromEmbed(interaction.Message.Embeds.FirstOrDefault());
+    await interaction.UpdateAsync(msg =>
+    {
+      progressTrack.Ticks += ticksToAdd;
+      progressTrack.Ticks = Math.Max(0, Math.Min(progressTrack.Ticks, 40));
+      msg.Components = progressTrack.MakeComponents().Build();
+      msg.Embed = progressTrack.ToEmbed().Build();
+    });
+  }
+  [ComponentInteraction("progress-clear:*")]
+  public async Task ClearProgress(string tickString
+  )
+  {
+    await MarkProgress("-" + tickString);
+  }
+  [ComponentInteraction("progress-recommit:*")]
+  public async Task RecommitProgress()
+  {
+    var interaction = Context.Interaction as SocketMessageComponent;
+    IProgressTrack.Recommit recommit = new(Random, interaction.Message.Embeds.FirstOrDefault());
+    await interaction.UpdateAsync(msg =>
+    {
+      msg.Embed = recommit.NewTrack.ToEmbed().Build();
+      msg.Components = recommit.NewTrack.MakeComponents().Build();
+    });
+    await interaction.FollowupAsync(embed: recommit.ToAlertEmbed().Build());
+  }
+  [ComponentInteraction("progress-roll:*")]
+  public async Task RollProgress(string scoreString)
+  {
+    var interaction = Context.Interaction as SocketMessageComponent;
+    var progressTrack = IProgressTrack.FromEmbed(interaction.Message.Embeds.FirstOrDefault());
+    await interaction.RespondAsync(embed: progressTrack.Resolve(Random).ToEmbed().Build());
+  }
+  [ComponentInteraction("progress-menu")]
+  public async Task ProgressMenu(string[] values)
+  {
+    string optionValue = values.FirstOrDefault();
+    var interaction = Context.Interaction as SocketMessageComponent;
+    IProgressTrack track = IProgressTrack.FromEmbed(interaction.Message.Embeds.FirstOrDefault());
+    string operation = optionValue.Split(":")[0];
+    string operationArg = optionValue.Split(":")[1];
+    switch (operation)
+    {
+      case "progress-clear":
+        await ClearProgress(operationArg);
+        return;
+      case "progress-mark":
+        await MarkProgress(operationArg);
+        return;
+      case "progress-roll":
+        await RollProgress(operationArg);
+        return;
+      case "progress-recommit":
+        await RecommitProgress();
+        return;
+    }
+    await interaction.UpdateAsync(msg =>
+    {
+      msg.Components = track.MakeComponents().Build();
+      msg.Embed = track.ToEmbed().Build();
+    });
+    return;
+  }
+  [ComponentInteraction("clock-reset")]
+  public async Task ResetClock()
+  {
+    var interaction = Context.Interaction as SocketMessageComponent;
+    var clock = IClock.FromEmbed(interaction.Message.Embeds.FirstOrDefault());
+    await interaction.UpdateAsync(msg =>
+  {
+    clock.Filled = 0;
+    msg.Components = clock.MakeComponents().Build();
+    msg.Embed = clock.ToEmbed().Build();
+  });
+  }
+  [ComponentInteraction("clock-advance")]
+  public async Task AdvanceClock()
+  {
+    var interaction = Context.Interaction as SocketMessageComponent;
+    var clock = IClock.FromEmbed(interaction.Message.Embeds.FirstOrDefault());
+    await interaction.UpdateAsync(msg =>
+    {
+      clock.Filled++;
+      msg.Components = clock.MakeComponents().Build();
+      msg.Embed = clock.ToEmbed().Build();
+    });
+    await interaction.FollowupAsync(embed: clock.AlertEmbed().Build());
+  }
+  [ComponentInteraction("clock-menu")]
+  public async Task ClockMenu(string[] values)
+  {
+    string optionValue = values.FirstOrDefault();
+    var interaction = Context.Interaction as SocketMessageComponent;
+    var clock = IClock.FromEmbed(interaction.Message.Embeds.FirstOrDefault());
+    if (int.TryParse(optionValue.Replace("clock-advance-", ""), out int odds))
+    {
+      OracleAnswer answer = new(Random, odds, $"Does the clock *{clock.Title}* advance?");
+      EmbedBuilder answerEmbed = answer.ToEmbed();
+      if (answer.IsYes)
+      {
+        clock.Filled += answer.IsMatch ? 2 : 1;
+        if (answer.IsMatch)
+        {
+          answerEmbed.WithFooter("You rolled a match! Envision how this situation or project gains dramatic support or inertia.");
+        }
+        string append = answer.IsMatch ? $"The clock advances **twice** to {clock.ToString()}." : $"The clock advances to {clock.ToString()}.";
+        answerEmbed.Description += "\n" + append;
+        answerEmbed = answerEmbed.WithThumbnailUrl(IClock.Images[clock.Segments][clock.Filled]);
+      }
+      if (!answer.IsYes)
+      {
+        if (answer.IsMatch)
+        {
+          answerEmbed = answerEmbed.WithFooter("You rolled a match! Envision a surprising turn of events which pits new factors or forces against the clock.");
+        }
+        answerEmbed.Description += "\n" + $"The clock remains at {clock.ToString()}";
+      }
+      answerEmbed = answerEmbed
+        .WithThumbnailUrl(IClock.Images[clock.Segments][clock.Filled])
+        .WithColor(IClock.ColorRamp[clock.Segments][clock.Filled]);
+      await interaction.UpdateAsync(msg =>
+      {
+        msg.Components = clock.MakeComponents().Build();
+        msg.Embed = clock.ToEmbed().Build();
+      });
+      await interaction.FollowupAsync(embed: answerEmbed.Build());
+      return;
+    }
+    switch (optionValue)
+    {
+      case "clock-reset":
+        clock.Filled = 0;
+        break;
+      case "clock-advance":
+        clock.Filled++;
+        break;
+      default:
+        throw new ArgumentOutOfRangeException(nameof(optionValue), "Could not parse integer or valid string from select menu option value.");
+    }
+    await interaction.UpdateAsync(msg =>
+    {
+      msg.Components = clock.MakeComponents().Build();
+      msg.Embed = clock.ToEmbed().Build();
+    });
+    await interaction.FollowupAsync(embed: clock.AlertEmbed().Build());
+    return;
+  }
+  [ComponentInteraction("scene-challenge-menu")]
+  public async Task SceneChallengeMenu(string[] values)
+  {
+    string optionValue = values.FirstOrDefault();
+    if (optionValue.StartsWith("progress"))
+    {
+      await ProgressMenu(values);
+      return;
+    }
+    if (optionValue.StartsWith("clock"))
+    {
+      await ClockMenu(values);
+      return;
+    }
+  }
+}

--- a/TheOracle2/Commands/ProgressTrackerCommand.cs
+++ b/TheOracle2/Commands/ProgressTrackerCommand.cs
@@ -1,172 +1,27 @@
 ﻿using Discord.Interactions;
 using Discord.WebSocket;
-
-namespace TheOracle2.Commands;
+using TheOracle2.GameObjects;
+namespace TheOracle2;
 
 public class ProgressTrackerCommand : InteractionModuleBase
 {
-  public const int dangerousTicks = 8;
-  public const int epicTicks = 1;
-  public const int extremeTicks = 2;
-  public const int formidableTicks = 4;
-  public const int totalTicks = 40;
-  public const int troublesomeTicks = 12;
-  private readonly Random random;
-
+  private readonly Random Random;
   public ProgressTrackerCommand(Random random)
   {
-    this.random = random;
+    Random = random;
   }
-
   [SlashCommand("track", "Creates a generic tracker for things like vows, expeditions, and combat")]
-  public async Task PostTracker(string Description, ChallengeRank Rank)
+  public async Task BuildProgressTrack(
+    [Summary(description: "A title for the progress track.")]
+    string title,
+    [Summary(description: "The challenge rank of the progress track.")]
+    ChallengeRank rank,
+    [Summary(description: "An optional description.")]
+    string description=""
+  )
   {
-    var embed = new EmbedBuilder()
-        .WithTitle("Progress Tracker")
-        .WithDescription(Description)
-        .WithFields(new EmbedFieldBuilder()
-        {
-          Name = "Difficulty",
-          Value = Rank.ToString(),
-          IsInline = true
-        })
-        .WithFields(new EmbedFieldBuilder()
-        {
-          Name = "Progress Bar",
-          Value = GetProgressGraphic(0),
-          IsInline = true
-        })
-        .WithFields(new EmbedFieldBuilder()
-        {
-          Name = "Progress Amount",
-          Value = BuildProgressAmount(0),
-          IsInline = true
-        })
-        .WithFooter($"Ticks: 0")
-        .Build();
-
-    var compBuilder = new ComponentBuilder()
-        .WithButton("-", "lose-progress", row: 0, style: ButtonStyle.Danger)
-        .WithButton("+", "add-progress", row: 0, style: ButtonStyle.Success)
-        .WithButton("#", "add-full-progress", row: 0, style: ButtonStyle.Secondary)
-        .WithButton(customId: "roll-progress", row: 0, style: ButtonStyle.Secondary, emote: new Emoji("🎲"))
-        ;
-
-    await RespondAsync(embed: embed, components: compBuilder.Build()).ConfigureAwait(false);
-  }
-
-  public virtual string GetProgressGraphic(int Ticks)
-  {
-    //Use standard characters as stand-ins so that we can do easy string math
-    string fill = new string('#', (int)Math.Floor(Ticks / 4d));
-    string finalTickMark = ((Ticks % 4) == 1) ? "-" : ((Ticks % 4) == 2) ? "+" : ((Ticks % 4) == 3) ? "*" : string.Empty;
-    fill = (fill + finalTickMark).PadRight(10, '·');
-    fill += "\u200C"; //special hidden character for mobile formatting small emojis
-
-    fill = String.Join(' ', fill.ToCharArray()); //Add spaces between each character
-
-    //Replace all the stand-in characters with emojis
-    fill = fill.Replace("·", "<:progress0:880599822468534374>");
-    fill = fill.Replace("-", "<:progress1:880599822736965702>");
-    fill = fill.Replace("+", "<:progress2:880599822724390922>");
-    fill = fill.Replace("*", "<:progress3:880599822736957470>");
-    fill = fill.Replace("#", "<:progress4:880599822820864060>");
-
-    return fill;
-  }
-
-  public virtual string BuildProgressAmount(int ticks)
-  {
-    return $"{(int)(ticks / 4)}/10";
-  }
-
-  [ComponentInteraction("add-progress")]
-  public async Task AddProgress()
-  {
-    var interaction = Context.Interaction as SocketMessageComponent;
-
-    await interaction.UpdateAsync(msg =>
-    {
-      var embed = interaction.Message.Embeds.FirstOrDefault().ToEmbedBuilder();
-      msg.Embeds = ChangeProgress(embed);
-    }).ConfigureAwait(false);
-  }
-
-  [ComponentInteraction("lose-progress")]
-  public async Task LoseProgress()
-  {
-    var interaction = Context.Interaction as SocketMessageComponent;
-
-    await interaction.UpdateAsync(msg =>
-    {
-      var embed = interaction.Message.Embeds.FirstOrDefault().ToEmbedBuilder();
-      msg.Embeds = ChangeProgress(embed, -1);
-    }).ConfigureAwait(false);
-  }
-
-  [ComponentInteraction("add-full-progress")]
-  public async Task AddFullProgress()
-  {
-    var interaction = Context.Interaction as SocketMessageComponent;
-
-    await interaction.UpdateAsync(msg =>
-    {
-      var embed = interaction.Message.Embeds.FirstOrDefault().ToEmbedBuilder();
-      msg.Embeds = ChangeProgress(embed, exactAmount: 4);
-    }).ConfigureAwait(false);
-  }
-
-  [ComponentInteraction("roll-progress")]
-  public async Task RollProgress()
-  {
-    var interaction = Context.Interaction as SocketMessageComponent;
-    if (!int.TryParse(interaction.Message.Embeds.FirstOrDefault().Footer?.Text?.Replace("Ticks: ", ""), out int ticks))
-    {
-      await RespondAsync("Unknown progress type");
-    }
-    var roll = new ProgressRoll(random, ticks / 4, interaction.Message.Embeds.FirstOrDefault().Description);
-
-    await interaction.RespondAsync(embed: roll.ToEmbed().WithAuthor($"Progress Roll").Build()).ConfigureAwait(false);
-  }
-
-  private Embed[] ChangeProgress(EmbedBuilder embed, int delta = 1, int? exactAmount = null)
-  {
-    if (!int.TryParse(embed.Footer.Text.Replace("Ticks: ", ""), out int ticks)) return new Embed[] { embed.Build() };
-    if (!Enum.TryParse<ChallengeRank>(embed.Fields.Find(f => f.Name == "Difficulty")?.Value.ToString(), out var rank)) return new Embed[] { embed.Build() };
-
-    ticks += (exactAmount == null) ? TicksToAdd(rank) * delta : exactAmount.Value;
-    embed.WithFooter($"Ticks: {ticks}");
-
-    int amountIndex = embed.Fields.FindIndex(f => f.Name == "Progress Amount");
-    embed.Fields[amountIndex].Value = BuildProgressAmount(ticks);
-
-    int barIndex = embed.Fields.FindIndex(f => f.Name == "Progress Bar");
-    embed.Fields[barIndex].Value = GetProgressGraphic(ticks);
-
-    return new Embed[] { embed.Build() };
-  }
-
-  public virtual int TicksToAdd(ChallengeRank rank)
-  {
-    switch (rank)
-    {
-      case ChallengeRank.Troublesome:
-        return troublesomeTicks;
-
-      case ChallengeRank.Dangerous:
-        return dangerousTicks;
-
-      case ChallengeRank.Formidable:
-        return formidableTicks;
-
-      case ChallengeRank.Extreme:
-        return extremeTicks;
-
-      case ChallengeRank.Epic:
-        return epicTicks;
-
-      default:
-        return 0;
-    }
+    GenericTrack track = new(rank: rank, ticks: 0, title: title, description: description);
+    await RespondAsync(embed: track.ToEmbed().Build(), components: track.MakeComponents().Build());
   }
 }
+

--- a/TheOracle2/ProgressTrack/CombatTrack.cs
+++ b/TheOracle2/ProgressTrack/CombatTrack.cs
@@ -2,5 +2,8 @@ namespace TheOracle2.GameObjects;
 
 public class CombatTrack : ProgressTrack
 {
+  public CombatTrack(ChallengeRank rank, int ticks = 0, string title = "", string description = "") : base(rank, ticks, title, description)
+  {
 
+  }
 }

--- a/TheOracle2/ProgressTrack/CombatTrack.cs
+++ b/TheOracle2/ProgressTrack/CombatTrack.cs
@@ -1,0 +1,6 @@
+namespace TheOracle2.GameObjects;
+
+public class CombatTrack : ProgressTrack
+{
+
+}

--- a/TheOracle2/ProgressTrack/CombatTrack.cs
+++ b/TheOracle2/ProgressTrack/CombatTrack.cs
@@ -3,7 +3,6 @@ namespace TheOracle2.GameObjects;
 public class CombatTrack : ProgressTrack
 {
   public CombatTrack(ChallengeRank rank, int ticks = 0, string title = "", string description = "") : base(rank, ticks, title, description)
-  {
-
-  }
+  { }
+  public override string EmbedCategory => "Combat Track";
 }

--- a/TheOracle2/ProgressTrack/ConnectionTrack.cs
+++ b/TheOracle2/ProgressTrack/ConnectionTrack.cs
@@ -1,0 +1,9 @@
+namespace TheOracle2.GameObjects;
+
+public class ConnectionTrack : ProgressTrack
+{
+  public ConnectionTrack(ChallengeRank rank, int ticks = 0, string title = "", string description = "") : base(rank, ticks, title, description)
+  {
+
+  }
+}

--- a/TheOracle2/ProgressTrack/ConnectionTrack.cs
+++ b/TheOracle2/ProgressTrack/ConnectionTrack.cs
@@ -6,4 +6,5 @@ public class ConnectionTrack : ProgressTrack
   {
 
   }
+  public override string EmbedCategory => "Connection Track";
 }

--- a/TheOracle2/ProgressTrack/ExpeditionTrack.cs
+++ b/TheOracle2/ProgressTrack/ExpeditionTrack.cs
@@ -1,0 +1,9 @@
+namespace TheOracle2.GameObjects;
+
+public class ExpeditionTrack : ProgressTrack
+{
+  public ExpeditionTrack(ChallengeRank rank, int ticks = 0, string title = "", string description = "") : base(rank, ticks, title, description)
+  {
+
+  }
+}

--- a/TheOracle2/ProgressTrack/ExpeditionTrack.cs
+++ b/TheOracle2/ProgressTrack/ExpeditionTrack.cs
@@ -6,4 +6,5 @@ public class ExpeditionTrack : ProgressTrack
   {
 
   }
+  public override string EmbedCategory => "Expedition Track";
 }

--- a/TheOracle2/ProgressTrack/GenericTrack.cs
+++ b/TheOracle2/ProgressTrack/GenericTrack.cs
@@ -1,0 +1,9 @@
+namespace TheOracle2.GameObjects;
+
+public class GenericTrack : ProgressTrack
+{
+  public GenericTrack(Embed embed) : base(embed) { }
+  public GenericTrack(ChallengeRank rank, int ticks = 0, string title = "", string description = "") : base(rank, ticks, title, description)
+  { }
+  public override string EmbedCategory => "Progress Track";
+}

--- a/TheOracle2/ProgressTrack/IProgressTrack.cs
+++ b/TheOracle2/ProgressTrack/IProgressTrack.cs
@@ -1,0 +1,57 @@
+namespace TheOracle2.GameObjects;
+
+public interface IProgressTrack
+{
+  public ChallengeRank Rank { get; set; }
+  public int Ticks { get; set; }
+  public int Score => (int)(Ticks / 4);
+  public static IProgressTrack FromEmbed(Embed embed)
+  {
+    EmbedField progressField = embed.Fields.Where(field => field.Name.StartsWith("Progress [")).FirstOrDefault();
+    int ticks = EmojiToTicks(progressField.Value);
+
+    // switch from author field - split at ":" and get the first
+
+  }
+  public string ProgressTypeString { get; }
+
+  public string ProgressScoreString {get;}
+
+
+  public static int EmojiToTicks(string emojiBar)
+  {
+    // might be better handled by extracting it from a customid, tbh
+    emojiBar = emojiBar.Replace("\u200C", "");
+    int index = 0;
+    foreach (string emoji in BarEmoji)
+    {
+      emojiBar = emojiBar.Replace(emoji, index.ToString());
+      index++;
+    }
+    IEnumerable<int> values = emojiBar.Split(" ").Cast<int>();
+    return values.Sum();
+  }
+
+  public static string TicksToEmoji(int ticks)
+  {
+    int score = ticks / 4;
+    int remainder = ticks % 4;
+    string fill = new('4', score);
+    string finalTickMark = (remainder == 0) ? string.Empty : remainder.ToString();
+    fill = (fill + finalTickMark).PadRight(10, '0');
+    var boxValues = fill.ToCharArray().Cast<int>();
+    var emojiStrings = boxValues.Select<int, string>(box => BarEmoji[box]);
+    fill = String.Join(" ", emojiStrings);
+    fill += "\u200C"; //special hidden character for mobile formatting small emojis
+    return fill;
+  }
+
+  public static readonly List<string> BarEmoji = new()
+  {
+    "<:progress0:880599822468534374>",
+    "<:progress1:880599822736965702>",
+    "<:progress2:880599822724390922>",
+    "<:progress3:880599822736957470>",
+    "<:progress4:880599822820864060>"
+  };
+}

--- a/TheOracle2/ProgressTrack/IProgressTrack.cs
+++ b/TheOracle2/ProgressTrack/IProgressTrack.cs
@@ -9,6 +9,7 @@ public interface IProgressTrack
   public int Ticks { get; set; }
   public int Score => (int)(Ticks / 4);
   public ComponentBuilder MakeComponents();
+  public ProgressRoll Resolve(Random random);
   public string EmbedCategory { get; }
   public string ProgressScoreString { get; }
   public static EmbedBuilder ToEmbed(string embedCategory, ChallengeRank rank, string title, string progressScoreString, int ticks)
@@ -18,16 +19,21 @@ public interface IProgressTrack
     .WithTitle(title)
     .WithFields(ToEmbedField(progressScoreString, ticks));
   }
-  public static EmbedFieldBuilder ToEmbedField(string progressScoreString, int ticks)
+  public static EmbedFieldBuilder ToEmbedField(string progressScoreString, int ticks, ChallengeRank challengeRank)
   {
     return new EmbedFieldBuilder()
-      .WithName($"Progress [{progressScoreString}]")
+      .WithName($"*{challengeRank}* Progress Track [{progressScoreString}]")
       .WithValue(TicksToEmoji(ticks))
       .WithIsInline(true);
   }
+
+  public static IProgressTrack FromField(EmbedField embedField)
+  {
+
+  }
   public static IProgressTrack FromEmbed(Embed embed)
   {
-    EmbedField progressField = embed.Fields.FirstOrDefault(field => field.Name.StartsWith("Progress ["));
+    EmbedField progressField = embed.Fields.FirstOrDefault(field => field.Name.StartsWith("Progress Track ["));
     int ticks = EmojiToTicks(progressField.Value);
     string[] toParse = embed.Author.ToString().Split(": ");
     var progressType = toParse[0];
@@ -71,7 +77,7 @@ public interface IProgressTrack
       emojiBar = emojiBar.Replace(emoji, index.ToString());
       index++;
     }
-    IEnumerable<int> values = emojiBar.Split(" ").Cast<int>();
+    IEnumerable<int> values = emojiBar.Split(" ").Select(item => int.Parse(item));
     return values.Sum();
   }
   public static string TicksToEmoji(int ticks)
@@ -81,8 +87,8 @@ public interface IProgressTrack
     string fill = new('4', score);
     string finalTickMark = (remainder == 0) ? string.Empty : remainder.ToString();
     fill = (fill + finalTickMark).PadRight(10, '0');
-    var boxValues = fill.ToCharArray().Cast<int>();
-    var emojiStrings = boxValues.Select<int, string>(box => BarEmoji[box]);
+    var boxValues = fill.ToCharArray().Select(item => item.ToString());
+    var emojiStrings = boxValues.Select(box => BarEmoji[int.Parse(box)]);
     fill = String.Join(" ", emojiStrings);
     fill += "\u200C"; //special hidden character for mobile formatting small emojis
     return fill;
@@ -92,38 +98,106 @@ public interface IProgressTrack
     return new ButtonBuilder()
       .WithLabel("Roll progress")
       .WithStyle(ButtonStyle.Success)
+      .WithCustomId($"progress-roll:{score}")
       .WithEmote(new Emoji("🎲"))
-      .WithCustomId($"progress-resolve:{score}")
     ;
+  }
+
+  public static SelectMenuOptionBuilder ResolveOption(int score)
+  {
+    return new SelectMenuOptionBuilder()
+      .WithLabel("Roll progress")
+      .WithValue($"progress-roll:{score}")
+      .WithEmote(new Emoji("🎲"))
+      ;
   }
   public static ButtonBuilder MarkButton(int addTicks)
   {
     return new ButtonBuilder()
       .WithLabel("Mark progress")
       .WithStyle(ButtonStyle.Primary)
-      .WithEmote(new Emoji(BarEmoji[4]))
+      .WithEmote(Emote.Parse(BarEmoji[Math.Min(4, addTicks)]))
       .WithCustomId($"progress-mark:{addTicks}")
     ;
+  }
+  public static SelectMenuOptionBuilder MarkOption(int addTicks)
+  {
+    return new SelectMenuOptionBuilder()
+      .WithLabel($"Mark {TickString(addTicks)} progress")
+      .WithEmote(Emote.Parse(BarEmoji[Math.Min(4, addTicks)]))
+      .WithValue($"progress-mark:{addTicks}")
+      ;
   }
   public static ButtonBuilder ClearButton(int subtractTicks)
   {
     return new ButtonBuilder()
       .WithLabel("Clear progress")
       .WithStyle(ButtonStyle.Danger)
-      .WithEmote(new Emoji(BarEmoji[0]))
       .WithCustomId($"progress-clear:{subtractTicks}")
+    .WithEmote(Emote.Parse(BarEmoji[0]))
     ;
   }
+
+  public static string TickString(int ticks)
+  {
+    if (ticks >= 3)
+    {
+      int boxes = ticks / 4;
+      int remainder = ticks % 4;
+      string result = boxes.ToString() + " " + (boxes > 1 ? "boxes" : "box");
+      if (remainder > 0)
+      {
+        result += $" and {remainder} ticks";
+      }
+      return result;
+    }
+    return $"{ticks} ticks";
+  }
+  public static SelectMenuOptionBuilder ClearOption(int subtractTicks)
+  {
+    return new SelectMenuOptionBuilder()
+      .WithLabel($"Clear {TickString(subtractTicks)} progress")
+      .WithEmote(Emote.Parse(BarEmoji[0]))
+      .WithValue($"progress-clear:{subtractTicks}")
+      ;
+  }
+
   public static ButtonBuilder RecommitButton(int currentTicks, ChallengeRank currentRank)
   {
     return new ButtonBuilder()
       .WithLabel("Recommit")
       .WithStyle(ButtonStyle.Secondary)
-      .WithEmote(new Emoji("🔄"))
       .WithCustomId($"progress-recommit:{currentTicks},{(int)currentRank}")
+      .WithEmote(new Emoji("🔄"))
     ;
   }
-  public static readonly Rank RankInfo = new();
+  public static readonly Dictionary<ChallengeRank, RankData> RankInfo = new()
+  {
+    {
+      ChallengeRank.None,
+      new RankData(rank: ChallengeRank.None, markTrack: 0, markLegacy: 0, suffer: 0)
+    },
+    {
+      ChallengeRank.Troublesome,
+      new RankData(rank: ChallengeRank.Troublesome, markTrack: 12, markLegacy: 1, suffer: 1)
+    },
+    {
+      ChallengeRank.Dangerous,
+      new RankData(rank: ChallengeRank.Dangerous, markTrack: 8, markLegacy: 2, suffer: 2)
+    },
+    {
+      ChallengeRank.Formidable,
+      new RankData(rank: ChallengeRank.Formidable, markTrack: 4, markLegacy: 4, suffer: 2)
+    },
+    {
+      ChallengeRank.Extreme,
+      new RankData(rank: ChallengeRank.Extreme, markTrack: 2, markLegacy: 8, suffer: 3)
+    },
+    {
+      ChallengeRank.Epic,
+      new RankData(rank: ChallengeRank.Epic, markTrack: 1, markLegacy: 12, suffer: 3)
+    }
+  };
   public static readonly List<string> BarEmoji = new()
   {
     "<:progress0:880599822468534374>",

--- a/TheOracle2/ProgressTrack/IProgressTrack.cs
+++ b/TheOracle2/ProgressTrack/IProgressTrack.cs
@@ -1,23 +1,66 @@
+using TheOracle2;
 namespace TheOracle2.GameObjects;
 
 public interface IProgressTrack
 {
   public ChallengeRank Rank { get; set; }
+  public string Title { get; set; }
+  public string Description { get; set; }
   public int Ticks { get; set; }
   public int Score => (int)(Ticks / 4);
+  public ComponentBuilder MakeComponents();
+  public string EmbedCategory { get; }
+  public string ProgressScoreString { get; }
+  public static EmbedBuilder ToEmbed(string embedCategory, ChallengeRank rank, string title, string progressScoreString, int ticks)
+  {
+    return new EmbedBuilder()
+    .WithAuthor($"{embedCategory}: {rank}")
+    .WithTitle(title)
+    .WithFields(ToEmbedField(progressScoreString, ticks));
+  }
+  public static EmbedFieldBuilder ToEmbedField(string progressScoreString, int ticks)
+  {
+    return new EmbedFieldBuilder()
+      .WithName($"Progress [{progressScoreString}]")
+      .WithValue(TicksToEmoji(ticks))
+      .WithIsInline(true);
+  }
   public static IProgressTrack FromEmbed(Embed embed)
   {
-    EmbedField progressField = embed.Fields.Where(field => field.Name.StartsWith("Progress [")).FirstOrDefault();
+    EmbedField progressField = embed.Fields.FirstOrDefault(field => field.Name.StartsWith("Progress ["));
     int ticks = EmojiToTicks(progressField.Value);
+    string[] toParse = embed.Author.ToString().Split(": ");
+    var progressType = toParse[0];
+    switch (progressType)
+    {
+      // case "Legacy Track":
+      //   if (Enum.TryParse<LegacyTrack.LegacyType>(toParse[1], out LegacyTrack.LegacyType legacyType))
+      //     return new LegacyTrack(legacyType);
+      //   break;
+      case "Scene Challenge":
+        return new SceneChallenge(embed);
+      default:
+        break;
+    }
 
-    // switch from author field - split at ":" and get the first
-
+    // if (Enum.TryParse<ChallengeRank>(toParse[1], out ChallengeRank rank))
+    // {
+    //   switch (progressType)
+    //   {
+    //     case "Combat Track":
+    //       break;
+    //     case "Expedition Track":
+    //       break;
+    //     case "Vow Track":
+    //       break;
+    //     case "Connection Track":
+    //       break;
+    //     default:
+    //       break;
+    //   }
+    // }
+    throw new Exception("Unable to parse embed into progress track.");
   }
-  public string ProgressTypeString { get; }
-
-  public string ProgressScoreString {get;}
-
-
   public static int EmojiToTicks(string emojiBar)
   {
     // might be better handled by extracting it from a customid, tbh
@@ -31,7 +74,6 @@ public interface IProgressTrack
     IEnumerable<int> values = emojiBar.Split(" ").Cast<int>();
     return values.Sum();
   }
-
   public static string TicksToEmoji(int ticks)
   {
     int score = ticks / 4;
@@ -45,7 +87,43 @@ public interface IProgressTrack
     fill += "\u200C"; //special hidden character for mobile formatting small emojis
     return fill;
   }
-
+  public static ButtonBuilder ResolveButton(int score)
+  {
+    return new ButtonBuilder()
+      .WithLabel("Roll progress")
+      .WithStyle(ButtonStyle.Success)
+      .WithEmote(new Emoji("🎲"))
+      .WithCustomId($"progress-resolve:{score}")
+    ;
+  }
+  public static ButtonBuilder MarkButton(int addTicks)
+  {
+    return new ButtonBuilder()
+      .WithLabel("Mark progress")
+      .WithStyle(ButtonStyle.Primary)
+      .WithEmote(new Emoji(BarEmoji[4]))
+      .WithCustomId($"progress-mark:{addTicks}")
+    ;
+  }
+  public static ButtonBuilder ClearButton(int subtractTicks)
+  {
+    return new ButtonBuilder()
+      .WithLabel("Clear progress")
+      .WithStyle(ButtonStyle.Danger)
+      .WithEmote(new Emoji(BarEmoji[0]))
+      .WithCustomId($"progress-clear:{subtractTicks}")
+    ;
+  }
+  public static ButtonBuilder RecommitButton(int currentTicks, ChallengeRank currentRank)
+  {
+    return new ButtonBuilder()
+      .WithLabel("Recommit")
+      .WithStyle(ButtonStyle.Secondary)
+      .WithEmote(new Emoji("🔄"))
+      .WithCustomId($"progress-recommit:{currentTicks},{(int)currentRank}")
+    ;
+  }
+  public static readonly Rank RankInfo = new();
   public static readonly List<string> BarEmoji = new()
   {
     "<:progress0:880599822468534374>",
@@ -54,4 +132,39 @@ public interface IProgressTrack
     "<:progress3:880599822736957470>",
     "<:progress4:880599822820864060>"
   };
+  public class Recommit
+  {
+    public Recommit(Random random, Embed progressEmbed)
+    {
+      OldTrack = FromEmbed(progressEmbed);
+      NewTrack = FromEmbed(progressEmbed);
+      Random = random;
+      ChallengeDie1 = new Die(Random, 10);
+      ChallengeDie2 = new Die(Random, 10);
+      int ticksToClear = BoxesToClear * 4;
+      NewTrack.Ticks = Math.Min(0, NewTrack.Ticks - ticksToClear);
+      NewTrack.Rank = (ChallengeRank)Math.Min(
+        ((int)OldTrack.Rank) + 1, 5);
+    }
+    public IProgressTrack OldTrack { get; }
+    public IProgressTrack NewTrack { get; set; }
+    public Random Random { get; }
+    public Die ChallengeDie1 { get; }
+    public Die ChallengeDie2 { get; }
+
+    public int BoxesToClear => Math.Min(ChallengeDie1.Value, ChallengeDie2.Value);
+    public EmbedBuilder ToAlertEmbed(string moveName)
+    {
+      string rankString = OldTrack.Rank == NewTrack.Rank ? NewTrack.Rank.ToString() : $"~~{OldTrack.Rank}~~ {NewTrack.Rank}";
+      return new EmbedBuilder()
+        .WithAuthor(moveName)
+        .WithTitle("Recommit")
+        .WithDescription($"You recommit to *{OldTrack.Title}*.")
+        .AddField("Challenge Dice", $"{ChallengeDie1.Value}, {ChallengeDie2.Value}", true)
+        .AddField("Boxes Cleared", $"{BoxesToClear}", true)
+        .AddField($"Progress ~~[{OldTrack.Score}/10]~~ {NewTrack.Score}/10]", TicksToEmoji(NewTrack.Ticks))
+        .AddField("Rank", rankString, true)
+        ;
+    }
+  }
 }

--- a/TheOracle2/ProgressTrack/LegacyTrack.cs
+++ b/TheOracle2/ProgressTrack/LegacyTrack.cs
@@ -2,6 +2,16 @@ namespace TheOracle2.GameObjects;
 
 public class LegacyTrack : ProgressTrack
 {
-  public LegacyTrack(LegacyType legacyType) : base(ChallengeRank.None) { }
-  public enum LegacyType { Quests, Discoveries, Bonds }
+  public LegacyTrack(Legacy legacy) : base(ChallengeRank.None)
+  {
+    Legacy = legacy;
+  }
+  public Legacy Legacy;
+  public override string EmbedCategory => $"{Legacy} Legacy Track";
+  public void Mark(ChallengeRank rewardRank)
+  {
+    Ticks += IProgressTrack.RankInfo[rewardRank].MarkLegacy;
+  }
 }
+
+public enum Legacy { Quests, Discoveries, Bonds }

--- a/TheOracle2/ProgressTrack/LegacyTrack.cs
+++ b/TheOracle2/ProgressTrack/LegacyTrack.cs
@@ -1,0 +1,7 @@
+namespace TheOracle2.GameObjects;
+
+public class LegacyTrack : ProgressTrack
+{
+  public LegacyTrack(LegacyType legacyType) : base(ChallengeRank.None) { }
+  public enum LegacyType { Quests, Discoveries, Bonds }
+}

--- a/TheOracle2/ProgressTrack/ProgressTrack.cs
+++ b/TheOracle2/ProgressTrack/ProgressTrack.cs
@@ -1,0 +1,28 @@
+namespace TheOracle2.GameObjects;
+
+public abstract class ProgressTrack : IProgressTrack
+{
+  public ProgressTrack(ChallengeRank rank, int ticks = 0, string title = "", string description = "")
+  {
+    Rank = rank;
+    Ticks = ticks;
+    Title = title;
+    Description = description;
+  }
+  public ChallengeRank Rank { get; set; }
+  public int Ticks { get; set; }
+  public string Title { get; set; }
+  public string Description { get; set; }
+  public int Score => (int)(Ticks / 4);
+  public virtual string ProgressTypeString => "Progress Track";
+
+  public string ProgressScoreString { get => $"{Score}/10"; }
+
+  public virtual EmbedBuilder ToEmbed()
+  {
+    return new EmbedBuilder()
+    .WithAuthor($"{ProgressTypeString}: {Rank}")
+    .AddField($"Progress [{ProgressScoreString}]", IProgressTrack.TicksToEmoji(Ticks));
+  }
+
+}

--- a/TheOracle2/ProgressTrack/ProgressTrack.cs
+++ b/TheOracle2/ProgressTrack/ProgressTrack.cs
@@ -2,47 +2,74 @@ namespace TheOracle2.GameObjects;
 
 public abstract class ProgressTrack : IProgressTrack
 {
-  public ProgressTrack(ChallengeRank rank, int ticks = 0, string title = "", string description = "")
+  protected internal ProgressTrack(Embed embed)
+  {
+    Rank = IProgressTrack.ParseEmbedRank(embed);
+    Ticks = Math.Max(Math.Min(IProgressTrack.ParseEmbedTicks(embed), 40), 0);
+    Title = embed.Title;
+    Description = embed.Description;
+  }
+
+  protected internal ProgressTrack(ChallengeRank rank, int ticks = 0, string title = "", string description = "")
   {
     Rank = rank;
-    Ticks = ticks;
+    Ticks = Math.Max(Math.Min(ticks, 40), 0);
     Title = title;
     Description = description;
   }
   public ChallengeRank Rank { get; set; }
   public int Ticks { get; set; }
-
-  public RankData RankInfo { get => IProgressTrack.RankInfo[Rank]; }
+  public RankData RankData { get => IProgressTrack.RankInfo[Rank]; }
   public string Title { get; set; }
   public string Description { get; set; }
   public int Score => (int)(Ticks / 4);
-  public virtual string EmbedCategory => "Progress Track";
-  public string ProgressScoreString { get => $"{Score}/10"; }
-  public virtual EmbedBuilder ToEmbed()
+  public abstract string EmbedCategory { get; }
+  public ProgressRoll Resolve(Random random)
   {
-    return IProgressTrack.ToEmbed(EmbedCategory, Rank, Title, ProgressScoreString, Ticks);
+    return new ProgressRoll(random, Score, Title);
+  }
+  public EmbedBuilder ToEmbed()
+  {
+    return IProgressTrack.MakeEmbed(EmbedCategory, Rank, Title, Ticks);
   }
   public virtual ButtonBuilder ClearButton()
   {
     return IProgressTrack
-      .ClearButton(RankInfo.MarkTrack)
+      .ClearButton(RankData.MarkTrack)
         .WithDisabled(Ticks == 0);
+  }
+  public virtual SelectMenuOptionBuilder ClearOption()
+  {
+    return IProgressTrack.ClearOption(RankData.MarkTrack);
   }
   public virtual ButtonBuilder MarkButton()
   {
     return IProgressTrack
-      .MarkButton(RankInfo.MarkTrack)
+      .MarkButton(RankData.MarkTrack)
         .WithDisabled(Score >= 10);
+  }
+  public virtual SelectMenuOptionBuilder MarkOption()
+  {
+    return IProgressTrack.MarkOption(RankData.MarkTrack);
   }
   public virtual ButtonBuilder ResolveButton()
   {
     return IProgressTrack
       .ResolveButton(Score);
   }
+  public virtual SelectMenuOptionBuilder ResolveOption()
+  {
+    return IProgressTrack.ResolveOption(Score);
+  }
   public virtual ButtonBuilder RecommitButton()
   {
     return IProgressTrack
       .RecommitButton(Ticks, Rank);
+  }
+
+  public virtual SelectMenuOptionBuilder RecommitOption()
+  {
+    return IProgressTrack.RecommitOption(Ticks, Rank);
   }
   public virtual ComponentBuilder MakeComponents()
   {

--- a/TheOracle2/ProgressTrack/ProgressTrack.cs
+++ b/TheOracle2/ProgressTrack/ProgressTrack.cs
@@ -11,18 +11,44 @@ public abstract class ProgressTrack : IProgressTrack
   }
   public ChallengeRank Rank { get; set; }
   public int Ticks { get; set; }
+
+  public RankData RankInfo { get => IProgressTrack.RankInfo[Rank]; }
   public string Title { get; set; }
   public string Description { get; set; }
   public int Score => (int)(Ticks / 4);
-  public virtual string ProgressTypeString => "Progress Track";
-
+  public virtual string EmbedCategory => "Progress Track";
   public string ProgressScoreString { get => $"{Score}/10"; }
-
   public virtual EmbedBuilder ToEmbed()
   {
-    return new EmbedBuilder()
-    .WithAuthor($"{ProgressTypeString}: {Rank}")
-    .AddField($"Progress [{ProgressScoreString}]", IProgressTrack.TicksToEmoji(Ticks));
+    return IProgressTrack.ToEmbed(EmbedCategory, Rank, Title, ProgressScoreString, Ticks);
   }
-
+  public virtual ButtonBuilder ClearButton()
+  {
+    return IProgressTrack
+      .ClearButton(RankInfo.MarkTrack)
+        .WithDisabled(Ticks == 0);
+  }
+  public virtual ButtonBuilder MarkButton()
+  {
+    return IProgressTrack
+      .MarkButton(RankInfo.MarkTrack)
+        .WithDisabled(Score >= 10);
+  }
+  public virtual ButtonBuilder ResolveButton()
+  {
+    return IProgressTrack
+      .ResolveButton(Score);
+  }
+  public virtual ButtonBuilder RecommitButton()
+  {
+    return IProgressTrack
+      .RecommitButton(Ticks, Rank);
+  }
+  public virtual ComponentBuilder MakeComponents()
+  {
+    return new ComponentBuilder()
+      .WithButton(ClearButton())
+      .WithButton(MarkButton())
+      .WithButton(ResolveButton());
+  }
 }

--- a/TheOracle2/ProgressTrack/SceneChallenge.cs
+++ b/TheOracle2/ProgressTrack/SceneChallenge.cs
@@ -1,6 +1,0 @@
-namespace TheOracle2.GameObjects;
-
-public class SceneChallenge : IProgressTrack, IClock
-{
-
-}

--- a/TheOracle2/ProgressTrack/SceneChallenge.cs
+++ b/TheOracle2/ProgressTrack/SceneChallenge.cs
@@ -1,0 +1,6 @@
+namespace TheOracle2.GameObjects;
+
+public class SceneChallenge : IProgressTrack, IClock
+{
+
+}

--- a/TheOracle2/ProgressTrack/VowTrack.cs
+++ b/TheOracle2/ProgressTrack/VowTrack.cs
@@ -6,4 +6,5 @@ public class VowTrack : ProgressTrack
   {
 
   }
+  public override string EmbedCategory => "Vow Track";
 }

--- a/TheOracle2/ProgressTrack/VowTrack.cs
+++ b/TheOracle2/ProgressTrack/VowTrack.cs
@@ -1,0 +1,9 @@
+namespace TheOracle2.GameObjects;
+
+public class VowTrack : ProgressTrack
+{
+  public VowTrack(ChallengeRank rank, int ticks = 0, string title = "", string description = "") : base(rank, ticks, title, description)
+  {
+
+  }
+}

--- a/TheOracle2/ProgressTrackers/ChallengeRank.cs
+++ b/TheOracle2/ProgressTrackers/ChallengeRank.cs
@@ -1,10 +1,44 @@
 ﻿namespace TheOracle2;
 
+public class RankData
+{
+  public RankData(ChallengeRank rank, int markTrack, int markLegacy, int? suffer = null)
+  {
+    Name = rank.ToString();
+    Value = (int)rank;
+    MarkTrack = markTrack;
+    MarkLegacy = markLegacy;
+    Suffer = suffer;
+  }
+  public string Name { get; set; }
+  public int Value { get; set; }
+  public int MarkTrack { get; set; }
+  public int MarkLegacy { get; set; }
+  public int? Suffer { get; set; }
+  public ChallengeRank ToEnumValue()
+  {
+    return (ChallengeRank)Value;
+  }
+}
+public class Rank : Dictionary<ChallengeRank, RankData>
+{
+  public Rank()
+  {
+    Add((ChallengeRank)0, new RankData(rank: (ChallengeRank)0, markTrack: 0, markLegacy: 0, suffer: 0));
+    Add((ChallengeRank)1, new RankData(rank: (ChallengeRank)1, markTrack: 12, markLegacy: 1, suffer: 1));
+    Add((ChallengeRank)2, new RankData(rank: (ChallengeRank)2, markTrack: 8, markLegacy: 2, suffer: 2));
+    Add((ChallengeRank)3, new RankData(rank: (ChallengeRank)3, markTrack: 4, markLegacy: 4, suffer: 2));
+    Add((ChallengeRank)4, new RankData(rank: (ChallengeRank)4, markTrack: 2, markLegacy: 8, suffer: 3));
+    Add((ChallengeRank)5, new RankData(rank: (ChallengeRank)5, markTrack: 1, markLegacy: 12, suffer: 3));
+  }
+}
+
 public enum ChallengeRank
 {
-    Troublesome,
-    Dangerous,
-    Formidable,
-    Extreme,
-    Epic
+  None = 0, // for Legacy Tracks, Troublesome quests granting less reward, etc
+  Troublesome = 1,
+  Dangerous = 2,
+  Formidable = 3,
+  Extreme = 4,
+  Epic = 5
 }

--- a/TheOracle2/ProgressTrackers/ChallengeRank.cs
+++ b/TheOracle2/ProgressTrackers/ChallengeRank.cs
@@ -20,25 +20,13 @@ public class RankData
     return (ChallengeRank)Value;
   }
 }
-public class Rank : Dictionary<ChallengeRank, RankData>
-{
-  public Rank()
-  {
-    Add((ChallengeRank)0, new RankData(rank: (ChallengeRank)0, markTrack: 0, markLegacy: 0, suffer: 0));
-    Add((ChallengeRank)1, new RankData(rank: (ChallengeRank)1, markTrack: 12, markLegacy: 1, suffer: 1));
-    Add((ChallengeRank)2, new RankData(rank: (ChallengeRank)2, markTrack: 8, markLegacy: 2, suffer: 2));
-    Add((ChallengeRank)3, new RankData(rank: (ChallengeRank)3, markTrack: 4, markLegacy: 4, suffer: 2));
-    Add((ChallengeRank)4, new RankData(rank: (ChallengeRank)4, markTrack: 2, markLegacy: 8, suffer: 3));
-    Add((ChallengeRank)5, new RankData(rank: (ChallengeRank)5, markTrack: 1, markLegacy: 12, suffer: 3));
-  }
-}
 
 public enum ChallengeRank
 {
-  None = 0, // for Legacy Tracks, Troublesome quests granting less reward, etc
-  Troublesome = 1,
-  Dangerous = 2,
-  Formidable = 3,
-  Extreme = 4,
-  Epic = 5
+  None,
+  Troublesome,
+  Dangerous,
+  Formidable,
+  Extreme,
+  Epic
 }


### PR DESCRIPTION
fully-functional progress tracks with clocks. numerous internal to progress fields to make them more modular, laying the groundwork for things like Legacies, NPCs with Bond progress tracks, etc. more utility methods than are probably necessary but help standardize parsing objects from embeds.

the most prominent user-facing changes:

the progress track Score has been moved to the name of the Track field. the field is wide anyways, might as well use the space and keep it concise.
<img width="230" alt="Screen Shot 2022-01-11 at 1 28 02 AM" src="https://user-images.githubusercontent.com/5354757/148916603-0273909d-b03e-4f12-84e6-6f3fa7cd4bed.png">


generic progress track buttons now all have labels + emoji. i may switch them to dropdowns. 

<img width="466" alt="Screen Shot 2022-01-11 at 1 35 35 AM" src="https://user-images.githubusercontent.com/5354757/148917740-0c1019e2-2ad3-4bba-91a1-436496682a1f.png">